### PR TITLE
fix: print message and don't run in nomodifiable buffers

### DIFF
--- a/lua/toggle-bool/init.lua
+++ b/lua/toggle-bool/init.lua
@@ -40,6 +40,10 @@ local function find_toggle_word(line)
 end
 
 M.toggle_bool = function()
+  if vim.o.modifiable == false then
+    vim.print("toggl-bool.nvim: Cannot toggle. Buffer is not modifiable.")
+    return
+  end
   local line = vim.api.nvim_get_current_line()
   local _, col = unpack(vim.api.nvim_win_get_cursor(0))
   local sub_line = string.sub(line, col + 1)


### PR DESCRIPTION
Hi @gerazov, thanks for you nice little plugin. I find it a little annoying if I get an error when toggling in a non-modifiable buffer, and I have to press enter to get rid of the error. So here's a little pull request that gets rid of the error and prints an informative message instead.